### PR TITLE
Add Jenkinsfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 /dist
 gulpfile.tmp.*
 junit.xml
+coverage/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,45 @@
+#! groovy
+library 'pipeline-library'
+
+timestamps {
+  def isMaster = false
+  def packageVersion
+  def nodeVersion = '8.11.1'
+  def npmVersion = '5.8.0'
+  node('osx || linux') {
+    stage('Checkout') {
+      // checkout scm
+      // Hack for JENKINS-37658 - see https://support.cloudbees.com/hc/en-us/articles/226122247-How-to-Customize-Checkout-for-Pipeline-Multibranch
+      // do a git clean before checking out
+      checkout([
+        $class: 'GitSCM',
+        branches: scm.branches,
+        extensions: scm.extensions + [[$class: 'CleanBeforeCheckout']],
+        userRemoteConfigs: scm.userRemoteConfigs
+      ])
+
+      isMaster = env.BRANCH_NAME.equals('master')
+      packageVersion = jsonParse(readFile('package.json'))['version']
+      currentBuild.displayName = "#${packageVersion}-${currentBuild.number}"
+    }
+
+    nodejs(nodeJSInstallationName: "node ${nodeVersion}") {
+      ansiColor('xterm') {
+        stage('Install') {
+          timeout(15) {
+            ensureNPM(npmVersion)
+            sh 'npm ci'
+            fingerprint 'package.json'
+          } // timeout
+        } // stage
+
+        // TODO: Anything other than test? Test also runs lint so pointless having a separate lint step
+
+        stage('Test') {
+            sh 'npx gulp coverage'
+        }
+
+      } // ansiColor
+    } // nodejs
+  } // node
+} // timestamps

--- a/package-lock.json
+++ b/package-lock.json
@@ -144,14 +144,6 @@
                 "lodash": "4.17.5",
                 "source-map": "0.5.7",
                 "trim-right": "1.0.1"
-            },
-            "dependencies": {
-                "jsesc": {
-                    "version": "2.5.1",
-                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-                    "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
-                    "dev": true
-                }
             }
         },
         "@babel/helper-annotate-as-pure": {
@@ -250,7 +242,7 @@
             "integrity": "sha512-r4snW6Q8ICL3Y8hGzYJRvyG/+sc+kvkewXNedG9tQjoHmUFMwMSv/o45GWQUQswevGnWghiGkpRPivFfOuMsOA==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.0",
+                "chalk": "2.4.1",
                 "esutils": "2.0.2",
                 "js-tokens": "3.0.2"
             }
@@ -289,14 +281,6 @@
                 "mkdirp": "0.5.1",
                 "pirates": "3.0.2",
                 "source-map-support": "0.4.18"
-            },
-            "dependencies": {
-                "home-or-tmp": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-3.0.0.tgz",
-                    "integrity": "sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs=",
-                    "dev": true
-                }
             }
         },
         "@babel/template": {
@@ -332,7 +316,7 @@
                 "@babel/types": "7.0.0-beta.46",
                 "babylon": "7.0.0-beta.46",
                 "debug": "3.1.0",
-                "globals": "11.4.0",
+                "globals": "11.5.0",
                 "invariant": "2.2.4",
                 "lodash": "4.17.5"
             },
@@ -374,9 +358,9 @@
             }
         },
         "@types/node": {
-            "version": "10.0.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.2.tgz",
-            "integrity": "sha512-DPbG0qQ5kdvXBK0jGdv1yd8vGN7hwH8sB2Q1z1kGaxtCnXkSxYJ009VccGlcgknYoLeMTYu4TTzOditDJMdP2Q==",
+            "version": "10.0.3",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.3.tgz",
+            "integrity": "sha512-J7nx6JzxmtT4zyvfLipYL7jNaxvlCWpyG7JhhCQ4fQyG+AGfovAHoYR55TFx+X8akfkUJYpt5JG6GPeFMjZaCQ==",
             "dev": true
         },
         "abab": {
@@ -387,9 +371,9 @@
             "optional": true
         },
         "acorn": {
-            "version": "5.5.3",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
-            "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+            "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
             "dev": true
         },
         "acorn-globals": {
@@ -400,15 +384,6 @@
             "optional": true,
             "requires": {
                 "acorn": "2.7.0"
-            },
-            "dependencies": {
-                "acorn": {
-                    "version": "2.7.0",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
-                    "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
-                    "dev": true,
-                    "optional": true
-                }
             }
         },
         "acorn-jsx": {
@@ -506,9 +481,9 @@
             "dev": true
         },
         "appcd-gulp": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/appcd-gulp/-/appcd-gulp-1.1.2.tgz",
-            "integrity": "sha512-mhqWniz37UVkD51gsnVFpYSM85xt0eWLV02C/bahWMPeF7SYW6vMupQF3zbxJo9Fz9nfejr5KrN5X/uYKBdIlg==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/appcd-gulp/-/appcd-gulp-1.1.3.tgz",
+            "integrity": "sha512-F/ba+sebXfLkdQdCI6QHTUokNYAT4SQPbkcIo7UOdP7z3yF2JO3ih9lZURoTQuQi8pdnIDwI0nQ/HOsl8uaMGg==",
             "dev": true,
             "requires": {
                 "@babel/core": "7.0.0-beta.46",
@@ -525,7 +500,7 @@
                 "babel-plugin-transform-es2015-modules-commonjs": "7.0.0-beta.3",
                 "babel-plugin-transform-es2015-parameters": "7.0.0-beta.3",
                 "babel-plugin-transform-object-rest-spread": "7.0.0-beta.3",
-                "babel-preset-minify": "0.4.0",
+                "babel-preset-minify": "0.4.1",
                 "chai": "4.1.2",
                 "chai-as-promised": "7.1.1",
                 "core-js": "2.5.5",
@@ -550,64 +525,6 @@
                 "sinon-chai": "3.0.0"
             },
             "dependencies": {
-                "babel-code-frame": {
-                    "version": "7.0.0-beta.3",
-                    "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-beta.3.tgz",
-                    "integrity": "sha512-flMsJ9eSpShupt2Gwpka84DoMePvE4HlDObzdEc+1iNkacv3+NHlsJ7dMKmbnVA/AT22UhcGEBHwbJLoXWBO6Q==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "2.4.0",
-                        "esutils": "2.0.2",
-                        "js-tokens": "3.0.2"
-                    }
-                },
-                "babel-helper-call-delegate": {
-                    "version": "7.0.0-beta.3",
-                    "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-7.0.0-beta.3.tgz",
-                    "integrity": "sha512-omi9OEknlyt8LxZ46SRVMY/20EpwU2GMkXHcswcGNANNcaB3aiDcYQRAgtU0vrhjD/+fIGb9xl7+plpUnADKIw==",
-                    "dev": true,
-                    "requires": {
-                        "babel-helper-hoist-variables": "7.0.0-beta.3",
-                        "babel-traverse": "7.0.0-beta.3",
-                        "babel-types": "7.0.0-beta.3"
-                    }
-                },
-                "babel-helper-function-name": {
-                    "version": "7.0.0-beta.3",
-                    "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-beta.3.tgz",
-                    "integrity": "sha512-iMWYqwDarQOVlEGcK1MfbtK9vrFGs5Z4UQsdASJUHdhBp918EM5kndwriiIbhUX8gr2B/CEV/udJkFTrHsjdMQ==",
-                    "dev": true,
-                    "requires": {
-                        "babel-helper-get-function-arity": "7.0.0-beta.3",
-                        "babel-template": "7.0.0-beta.3",
-                        "babel-traverse": "7.0.0-beta.3",
-                        "babel-types": "7.0.0-beta.3"
-                    }
-                },
-                "babel-helper-get-function-arity": {
-                    "version": "7.0.0-beta.3",
-                    "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-beta.3.tgz",
-                    "integrity": "sha512-ZkYFRMWKx1c9fUW72YNM3eieBG701CMbLjmLLWmJTTPc0F0kddS9Fwok26EAmndUAgD6kFdh7ms3PH94MdGuGQ==",
-                    "dev": true,
-                    "requires": {
-                        "babel-types": "7.0.0-beta.3"
-                    }
-                },
-                "babel-helper-hoist-variables": {
-                    "version": "7.0.0-beta.3",
-                    "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-7.0.0-beta.3.tgz",
-                    "integrity": "sha512-9XOLW0nN3154gYf0OrRpatRYpB5s5NkRAcFseGYn/sxf+450iURwq442O7USvg9dRl1WWBgH23fsQQ5+xjKsGw==",
-                    "dev": true,
-                    "requires": {
-                        "babel-types": "7.0.0-beta.3"
-                    }
-                },
-                "babel-plugin-transform-es2015-destructuring": {
-                    "version": "7.0.0-beta.3",
-                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-7.0.0-beta.3.tgz",
-                    "integrity": "sha512-BDjEuIS7SCI7mGEO8lfvo4f3UAVLwZYjHwt1WqRNklc1Y0mcY0/UZzM3NHoa+eBxkNPl5XApwyha/rxW3XyLUQ==",
-                    "dev": true
-                },
                 "babel-plugin-transform-es2015-modules-commonjs": {
                     "version": "7.0.0-beta.3",
                     "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-7.0.0-beta.3.tgz",
@@ -617,48 +534,6 @@
                         "babel-helper-module-transforms": "7.0.0-beta.3",
                         "babel-helper-simple-access": "7.0.0-beta.3",
                         "babel-types": "7.0.0-beta.3"
-                    }
-                },
-                "babel-plugin-transform-es2015-parameters": {
-                    "version": "7.0.0-beta.3",
-                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-7.0.0-beta.3.tgz",
-                    "integrity": "sha512-0LdLhxyhIZz5y+1jfRSM7uBen5dCIft3KWwLbr/Wy3Amz9V4Mnfn1mr25BIBDL/RTNYpZGrJ2DWan7KD7DoHEA==",
-                    "dev": true,
-                    "requires": {
-                        "babel-helper-call-delegate": "7.0.0-beta.3",
-                        "babel-helper-get-function-arity": "7.0.0-beta.3",
-                        "babel-template": "7.0.0-beta.3",
-                        "babel-traverse": "7.0.0-beta.3",
-                        "babel-types": "7.0.0-beta.3"
-                    }
-                },
-                "babel-template": {
-                    "version": "7.0.0-beta.3",
-                    "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-7.0.0-beta.3.tgz",
-                    "integrity": "sha512-urJduLja89kSDGqY8ryw8iIwQnMl30IvhMtMNmDD7vBX0l0oylaLgK+7df/9ODX9vR/PhXuif6HYl5HlzAKXMg==",
-                    "dev": true,
-                    "requires": {
-                        "babel-code-frame": "7.0.0-beta.3",
-                        "babel-traverse": "7.0.0-beta.3",
-                        "babel-types": "7.0.0-beta.3",
-                        "babylon": "7.0.0-beta.27",
-                        "lodash": "4.17.5"
-                    }
-                },
-                "babel-traverse": {
-                    "version": "7.0.0-beta.3",
-                    "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-beta.3.tgz",
-                    "integrity": "sha512-xyh/aPYuedMAfQlSj2kjHjsEmY5/Dpxs576L05DySAVMrV+ADX6l4mTOLysAEGwJfkePJlDLhFuS6SKaxv1V7w==",
-                    "dev": true,
-                    "requires": {
-                        "babel-code-frame": "7.0.0-beta.3",
-                        "babel-helper-function-name": "7.0.0-beta.3",
-                        "babel-types": "7.0.0-beta.3",
-                        "babylon": "7.0.0-beta.27",
-                        "debug": "3.1.0",
-                        "globals": "10.4.0",
-                        "invariant": "2.2.4",
-                        "lodash": "4.17.5"
                     }
                 },
                 "babel-types": {
@@ -671,77 +546,6 @@
                         "lodash": "4.17.5",
                         "to-fast-properties": "2.0.0"
                     }
-                },
-                "babylon": {
-                    "version": "7.0.0-beta.27",
-                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.27.tgz",
-                    "integrity": "sha512-ksRx+r8eFIfdt63MCgLc9VxGL7W3jcyveQvMpNMVHgW+eb9mq3Xbm45FLCNkw8h92RvoNp4uuiwzcCEwxjDBZg==",
-                    "dev": true
-                },
-                "del": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
-                    "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
-                    "dev": true,
-                    "requires": {
-                        "globby": "6.1.0",
-                        "is-path-cwd": "1.0.0",
-                        "is-path-in-cwd": "1.0.1",
-                        "p-map": "1.2.0",
-                        "pify": "3.0.0",
-                        "rimraf": "2.6.2"
-                    }
-                },
-                "globals": {
-                    "version": "10.4.0",
-                    "resolved": "https://registry.npmjs.org/globals/-/globals-10.4.0.tgz",
-                    "integrity": "sha512-uNUtxIZpGyuaq+5BqGGQHsL4wUlJAXRqOm6g3Y48/CWNGTLONgBibI0lh6lGxjR2HljFYUfszb+mk4WkgMntsA==",
-                    "dev": true
-                },
-                "globby": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-                    "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-                    "dev": true,
-                    "requires": {
-                        "array-union": "1.0.2",
-                        "glob": "7.1.2",
-                        "object-assign": "4.1.1",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
-                    },
-                    "dependencies": {
-                        "pify": {
-                            "version": "2.3.0",
-                            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-                            "dev": true
-                        }
-                    }
-                },
-                "gulp-babel": {
-                    "version": "8.0.0-beta.2",
-                    "resolved": "https://registry.npmjs.org/gulp-babel/-/gulp-babel-8.0.0-beta.2.tgz",
-                    "integrity": "sha512-GTC2PxAXWkp6u1fP+C5+kn5biQ0dKGhkOSSXvKAf3ykF0+R3tevmLm/zSIkc1+S7U1JwH3XTvuMwRL6LD+sEiw==",
-                    "dev": true,
-                    "requires": {
-                        "plugin-error": "1.0.1",
-                        "replace-ext": "1.0.0",
-                        "through2": "2.0.3",
-                        "vinyl-sourcemaps-apply": "0.2.1"
-                    }
-                },
-                "pify": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-                    "dev": true
-                },
-                "replace-ext": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
-                    "dev": true
                 },
                 "to-fast-properties": {
                     "version": "2.0.0",
@@ -969,7 +773,7 @@
                     "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.4.0",
+                        "chalk": "2.4.1",
                         "esutils": "2.0.2",
                         "js-tokens": "3.0.2"
                     }
@@ -999,7 +803,7 @@
                         "@babel/types": "7.0.0-beta.44",
                         "babylon": "7.0.0-beta.44",
                         "debug": "3.1.0",
-                        "globals": "11.4.0",
+                        "globals": "11.5.0",
                         "invariant": "2.2.4",
                         "lodash": "4.17.5"
                     }
@@ -1019,12 +823,6 @@
                     "version": "7.0.0-beta.44",
                     "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
                     "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
-                    "dev": true
-                },
-                "jsesc": {
-                    "version": "2.5.1",
-                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-                    "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
                     "dev": true
                 },
                 "to-fast-properties": {
@@ -1059,17 +857,225 @@
                 }
             }
         },
+        "babel-helper-call-delegate": {
+            "version": "7.0.0-beta.3",
+            "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-7.0.0-beta.3.tgz",
+            "integrity": "sha512-omi9OEknlyt8LxZ46SRVMY/20EpwU2GMkXHcswcGNANNcaB3aiDcYQRAgtU0vrhjD/+fIGb9xl7+plpUnADKIw==",
+            "dev": true,
+            "requires": {
+                "babel-helper-hoist-variables": "7.0.0-beta.3",
+                "babel-traverse": "7.0.0-beta.3",
+                "babel-types": "7.0.0-beta.3"
+            },
+            "dependencies": {
+                "babel-code-frame": {
+                    "version": "7.0.0-beta.3",
+                    "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-beta.3.tgz",
+                    "integrity": "sha512-flMsJ9eSpShupt2Gwpka84DoMePvE4HlDObzdEc+1iNkacv3+NHlsJ7dMKmbnVA/AT22UhcGEBHwbJLoXWBO6Q==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "2.4.1",
+                        "esutils": "2.0.2",
+                        "js-tokens": "3.0.2"
+                    }
+                },
+                "babel-traverse": {
+                    "version": "7.0.0-beta.3",
+                    "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-beta.3.tgz",
+                    "integrity": "sha512-xyh/aPYuedMAfQlSj2kjHjsEmY5/Dpxs576L05DySAVMrV+ADX6l4mTOLysAEGwJfkePJlDLhFuS6SKaxv1V7w==",
+                    "dev": true,
+                    "requires": {
+                        "babel-code-frame": "7.0.0-beta.3",
+                        "babel-helper-function-name": "7.0.0-beta.3",
+                        "babel-types": "7.0.0-beta.3",
+                        "babylon": "7.0.0-beta.27",
+                        "debug": "3.1.0",
+                        "globals": "10.4.0",
+                        "invariant": "2.2.4",
+                        "lodash": "4.17.5"
+                    }
+                },
+                "babel-types": {
+                    "version": "7.0.0-beta.3",
+                    "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-beta.3.tgz",
+                    "integrity": "sha512-36k8J+byAe181OmCMawGhw+DtKO7AwexPVtsPXoMfAkjtZgoCX3bEuHWfdE5sYxRM8dojvtG/+O08M0Z/YDC6w==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "2.0.2",
+                        "lodash": "4.17.5",
+                        "to-fast-properties": "2.0.0"
+                    }
+                },
+                "babylon": {
+                    "version": "7.0.0-beta.27",
+                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.27.tgz",
+                    "integrity": "sha512-ksRx+r8eFIfdt63MCgLc9VxGL7W3jcyveQvMpNMVHgW+eb9mq3Xbm45FLCNkw8h92RvoNp4uuiwzcCEwxjDBZg==",
+                    "dev": true
+                },
+                "globals": {
+                    "version": "10.4.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-10.4.0.tgz",
+                    "integrity": "sha512-uNUtxIZpGyuaq+5BqGGQHsL4wUlJAXRqOm6g3Y48/CWNGTLONgBibI0lh6lGxjR2HljFYUfszb+mk4WkgMntsA==",
+                    "dev": true
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
+        },
         "babel-helper-evaluate-path": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.4.0.tgz",
-            "integrity": "sha1-LOvZ0j89wckSMpTntcD/M07BlDQ=",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.4.1.tgz",
+            "integrity": "sha1-a3XB4OMPFmKfKoZFyjBeGo01iaY=",
             "dev": true
         },
         "babel-helper-flip-expressions": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.4.0.tgz",
-            "integrity": "sha1-NB2f+AKRNeidsbjpp1snxMxL8Ko=",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.4.1.tgz",
+            "integrity": "sha1-zAPYBFjBA7n1BcHGpn++D1nKwyA=",
             "dev": true
+        },
+        "babel-helper-function-name": {
+            "version": "7.0.0-beta.3",
+            "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-beta.3.tgz",
+            "integrity": "sha512-iMWYqwDarQOVlEGcK1MfbtK9vrFGs5Z4UQsdASJUHdhBp918EM5kndwriiIbhUX8gr2B/CEV/udJkFTrHsjdMQ==",
+            "dev": true,
+            "requires": {
+                "babel-helper-get-function-arity": "7.0.0-beta.3",
+                "babel-template": "7.0.0-beta.3",
+                "babel-traverse": "7.0.0-beta.3",
+                "babel-types": "7.0.0-beta.3"
+            },
+            "dependencies": {
+                "babel-code-frame": {
+                    "version": "7.0.0-beta.3",
+                    "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-beta.3.tgz",
+                    "integrity": "sha512-flMsJ9eSpShupt2Gwpka84DoMePvE4HlDObzdEc+1iNkacv3+NHlsJ7dMKmbnVA/AT22UhcGEBHwbJLoXWBO6Q==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "2.4.1",
+                        "esutils": "2.0.2",
+                        "js-tokens": "3.0.2"
+                    }
+                },
+                "babel-template": {
+                    "version": "7.0.0-beta.3",
+                    "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-7.0.0-beta.3.tgz",
+                    "integrity": "sha512-urJduLja89kSDGqY8ryw8iIwQnMl30IvhMtMNmDD7vBX0l0oylaLgK+7df/9ODX9vR/PhXuif6HYl5HlzAKXMg==",
+                    "dev": true,
+                    "requires": {
+                        "babel-code-frame": "7.0.0-beta.3",
+                        "babel-traverse": "7.0.0-beta.3",
+                        "babel-types": "7.0.0-beta.3",
+                        "babylon": "7.0.0-beta.27",
+                        "lodash": "4.17.5"
+                    }
+                },
+                "babel-traverse": {
+                    "version": "7.0.0-beta.3",
+                    "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-beta.3.tgz",
+                    "integrity": "sha512-xyh/aPYuedMAfQlSj2kjHjsEmY5/Dpxs576L05DySAVMrV+ADX6l4mTOLysAEGwJfkePJlDLhFuS6SKaxv1V7w==",
+                    "dev": true,
+                    "requires": {
+                        "babel-code-frame": "7.0.0-beta.3",
+                        "babel-helper-function-name": "7.0.0-beta.3",
+                        "babel-types": "7.0.0-beta.3",
+                        "babylon": "7.0.0-beta.27",
+                        "debug": "3.1.0",
+                        "globals": "10.4.0",
+                        "invariant": "2.2.4",
+                        "lodash": "4.17.5"
+                    }
+                },
+                "babel-types": {
+                    "version": "7.0.0-beta.3",
+                    "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-beta.3.tgz",
+                    "integrity": "sha512-36k8J+byAe181OmCMawGhw+DtKO7AwexPVtsPXoMfAkjtZgoCX3bEuHWfdE5sYxRM8dojvtG/+O08M0Z/YDC6w==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "2.0.2",
+                        "lodash": "4.17.5",
+                        "to-fast-properties": "2.0.0"
+                    }
+                },
+                "babylon": {
+                    "version": "7.0.0-beta.27",
+                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.27.tgz",
+                    "integrity": "sha512-ksRx+r8eFIfdt63MCgLc9VxGL7W3jcyveQvMpNMVHgW+eb9mq3Xbm45FLCNkw8h92RvoNp4uuiwzcCEwxjDBZg==",
+                    "dev": true
+                },
+                "globals": {
+                    "version": "10.4.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-10.4.0.tgz",
+                    "integrity": "sha512-uNUtxIZpGyuaq+5BqGGQHsL4wUlJAXRqOm6g3Y48/CWNGTLONgBibI0lh6lGxjR2HljFYUfszb+mk4WkgMntsA==",
+                    "dev": true
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
+        },
+        "babel-helper-get-function-arity": {
+            "version": "7.0.0-beta.3",
+            "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-beta.3.tgz",
+            "integrity": "sha512-ZkYFRMWKx1c9fUW72YNM3eieBG701CMbLjmLLWmJTTPc0F0kddS9Fwok26EAmndUAgD6kFdh7ms3PH94MdGuGQ==",
+            "dev": true,
+            "requires": {
+                "babel-types": "7.0.0-beta.3"
+            },
+            "dependencies": {
+                "babel-types": {
+                    "version": "7.0.0-beta.3",
+                    "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-beta.3.tgz",
+                    "integrity": "sha512-36k8J+byAe181OmCMawGhw+DtKO7AwexPVtsPXoMfAkjtZgoCX3bEuHWfdE5sYxRM8dojvtG/+O08M0Z/YDC6w==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "2.0.2",
+                        "lodash": "4.17.5",
+                        "to-fast-properties": "2.0.0"
+                    }
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
+        },
+        "babel-helper-hoist-variables": {
+            "version": "7.0.0-beta.3",
+            "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-7.0.0-beta.3.tgz",
+            "integrity": "sha512-9XOLW0nN3154gYf0OrRpatRYpB5s5NkRAcFseGYn/sxf+450iURwq442O7USvg9dRl1WWBgH23fsQQ5+xjKsGw==",
+            "dev": true,
+            "requires": {
+                "babel-types": "7.0.0-beta.3"
+            },
+            "dependencies": {
+                "babel-types": {
+                    "version": "7.0.0-beta.3",
+                    "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-beta.3.tgz",
+                    "integrity": "sha512-36k8J+byAe181OmCMawGhw+DtKO7AwexPVtsPXoMfAkjtZgoCX3bEuHWfdE5sYxRM8dojvtG/+O08M0Z/YDC6w==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "2.0.2",
+                        "lodash": "4.17.5",
+                        "to-fast-properties": "2.0.0"
+                    }
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
         },
         "babel-helper-is-nodes-equiv": {
             "version": "0.0.1",
@@ -1078,15 +1084,15 @@
             "dev": true
         },
         "babel-helper-is-void-0": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.4.0.tgz",
-            "integrity": "sha1-/4aSGK3cras60wFH0zXS3vOV830=",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.4.1.tgz",
+            "integrity": "sha1-ogu127ocMMSq/nPrMn0tGLKE7Ro=",
             "dev": true
         },
         "babel-helper-mark-eval-scopes": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.4.0.tgz",
-            "integrity": "sha1-tDJlrC3OZFHZlcMI9604bGkXBx8=",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.4.1.tgz",
+            "integrity": "sha1-A/nMmN76R0fnQS5wD069D+1ktXE=",
             "dev": true
         },
         "babel-helper-module-imports": {
@@ -1137,30 +1143,9 @@
                     "integrity": "sha512-flMsJ9eSpShupt2Gwpka84DoMePvE4HlDObzdEc+1iNkacv3+NHlsJ7dMKmbnVA/AT22UhcGEBHwbJLoXWBO6Q==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.4.0",
+                        "chalk": "2.4.1",
                         "esutils": "2.0.2",
                         "js-tokens": "3.0.2"
-                    }
-                },
-                "babel-helper-function-name": {
-                    "version": "7.0.0-beta.3",
-                    "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-beta.3.tgz",
-                    "integrity": "sha512-iMWYqwDarQOVlEGcK1MfbtK9vrFGs5Z4UQsdASJUHdhBp918EM5kndwriiIbhUX8gr2B/CEV/udJkFTrHsjdMQ==",
-                    "dev": true,
-                    "requires": {
-                        "babel-helper-get-function-arity": "7.0.0-beta.3",
-                        "babel-template": "7.0.0-beta.3",
-                        "babel-traverse": "7.0.0-beta.3",
-                        "babel-types": "7.0.0-beta.3"
-                    }
-                },
-                "babel-helper-get-function-arity": {
-                    "version": "7.0.0-beta.3",
-                    "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-beta.3.tgz",
-                    "integrity": "sha512-ZkYFRMWKx1c9fUW72YNM3eieBG701CMbLjmLLWmJTTPc0F0kddS9Fwok26EAmndUAgD6kFdh7ms3PH94MdGuGQ==",
-                    "dev": true,
-                    "requires": {
-                        "babel-types": "7.0.0-beta.3"
                     }
                 },
                 "babel-template": {
@@ -1224,9 +1209,9 @@
             }
         },
         "babel-helper-remove-or-void": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.4.0.tgz",
-            "integrity": "sha1-ZUqcwtzCF+vtZmy0SqaH3FtwVzE=",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.4.1.tgz",
+            "integrity": "sha1-rdWwiBeFOVESpw8PHCWRebFSQmo=",
             "dev": true
         },
         "babel-helper-simple-access": {
@@ -1246,30 +1231,9 @@
                     "integrity": "sha512-flMsJ9eSpShupt2Gwpka84DoMePvE4HlDObzdEc+1iNkacv3+NHlsJ7dMKmbnVA/AT22UhcGEBHwbJLoXWBO6Q==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.4.0",
+                        "chalk": "2.4.1",
                         "esutils": "2.0.2",
                         "js-tokens": "3.0.2"
-                    }
-                },
-                "babel-helper-function-name": {
-                    "version": "7.0.0-beta.3",
-                    "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-beta.3.tgz",
-                    "integrity": "sha512-iMWYqwDarQOVlEGcK1MfbtK9vrFGs5Z4UQsdASJUHdhBp918EM5kndwriiIbhUX8gr2B/CEV/udJkFTrHsjdMQ==",
-                    "dev": true,
-                    "requires": {
-                        "babel-helper-get-function-arity": "7.0.0-beta.3",
-                        "babel-template": "7.0.0-beta.3",
-                        "babel-traverse": "7.0.0-beta.3",
-                        "babel-types": "7.0.0-beta.3"
-                    }
-                },
-                "babel-helper-get-function-arity": {
-                    "version": "7.0.0-beta.3",
-                    "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-beta.3.tgz",
-                    "integrity": "sha512-ZkYFRMWKx1c9fUW72YNM3eieBG701CMbLjmLLWmJTTPc0F0kddS9Fwok26EAmndUAgD6kFdh7ms3PH94MdGuGQ==",
-                    "dev": true,
-                    "requires": {
-                        "babel-types": "7.0.0-beta.3"
                     }
                 },
                 "babel-template": {
@@ -1333,9 +1297,9 @@
             }
         },
         "babel-helper-to-multiple-sequence-expressions": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.4.0.tgz",
-            "integrity": "sha1-RYr9QuIYUXaYFbjz0CtqUf9u6bc=",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.4.1.tgz",
+            "integrity": "sha1-FU7MOBGPXBybDp/CNd21OSFJvI8=",
             "dev": true
         },
         "babel-messages": {
@@ -1369,98 +1333,98 @@
             }
         },
         "babel-plugin-minify-builtins": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.4.0.tgz",
-            "integrity": "sha1-UwhjVq5FvhHZM1551bjfjZm1bcY=",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.4.1.tgz",
+            "integrity": "sha1-d6iMt2EO2SWxsCVKmQJAKR4LC+A=",
             "dev": true,
             "requires": {
-                "babel-helper-evaluate-path": "0.4.0"
+                "babel-helper-evaluate-path": "0.4.1"
             }
         },
         "babel-plugin-minify-constant-folding": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.4.0.tgz",
-            "integrity": "sha1-HKygo4kURlw1pw9okMmIJQxNTic=",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.4.1.tgz",
+            "integrity": "sha1-LtT4Ow/yj01VU9CcXvyFtdti0RI=",
             "dev": true,
             "requires": {
-                "babel-helper-evaluate-path": "0.4.0"
+                "babel-helper-evaluate-path": "0.4.1"
             }
         },
         "babel-plugin-minify-dead-code-elimination": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.4.0.tgz",
-            "integrity": "sha1-FWp7he8xf9D/ENcLeSJyQzVYhPo=",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.4.1.tgz",
+            "integrity": "sha1-81/PNIk06wqslEUCrTA3KRgu6yE=",
             "dev": true,
             "requires": {
-                "babel-helper-evaluate-path": "0.4.0",
-                "babel-helper-mark-eval-scopes": "0.4.0",
-                "babel-helper-remove-or-void": "0.4.0",
+                "babel-helper-evaluate-path": "0.4.1",
+                "babel-helper-mark-eval-scopes": "0.4.1",
+                "babel-helper-remove-or-void": "0.4.1",
                 "lodash.some": "4.6.0"
             }
         },
         "babel-plugin-minify-flip-comparisons": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.4.0.tgz",
-            "integrity": "sha1-vC1v7gCqoRNsbWdTMS9Uo63bYKM=",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.4.1.tgz",
+            "integrity": "sha1-5wfl2rxpXJnNKSP+lw7ZrHjE5ws=",
             "dev": true,
             "requires": {
-                "babel-helper-is-void-0": "0.4.0"
+                "babel-helper-is-void-0": "0.4.1"
             }
         },
         "babel-plugin-minify-guarded-expressions": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.4.0.tgz",
-            "integrity": "sha1-t1xhxNFKV61syjcZJPO4xZICeJ8=",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.4.1.tgz",
+            "integrity": "sha1-ylpZoGvBwi3Vz9mWpnUWOm9hm30=",
             "dev": true,
             "requires": {
-                "babel-helper-flip-expressions": "0.4.0"
+                "babel-helper-flip-expressions": "0.4.1"
             }
         },
         "babel-plugin-minify-infinity": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.4.0.tgz",
-            "integrity": "sha1-cHYDQDKyucf7Ru9reH1VDWl5DCE=",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.4.1.tgz",
+            "integrity": "sha1-zJw33MFmbcB/HrR4wrchoRz7lJE=",
             "dev": true
         },
         "babel-plugin-minify-mangle-names": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.4.0.tgz",
-            "integrity": "sha1-0SdB+2TdKOubQv4eESmDglEsEDM=",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.4.1.tgz",
+            "integrity": "sha1-d76P7TUOkxo6qaCfl/KCYWgIMTM=",
             "dev": true,
             "requires": {
-                "babel-helper-mark-eval-scopes": "0.4.0"
+                "babel-helper-mark-eval-scopes": "0.4.1"
             }
         },
         "babel-plugin-minify-numeric-literals": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.4.0.tgz",
-            "integrity": "sha1-l7VPY0HH3FJSb5Z/A7mHwy4q3GE=",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.4.1.tgz",
+            "integrity": "sha1-lktObMdIfG1KMalRl8P0IbYMmkc=",
             "dev": true
         },
         "babel-plugin-minify-replace": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.4.0.tgz",
-            "integrity": "sha1-O7gElNw0CywZ69j7sUMWkdjTRCk=",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.4.1.tgz",
+            "integrity": "sha1-xRnYhYxiKySWo2SmE1rSd1V42UM=",
             "dev": true
         },
         "babel-plugin-minify-simplify": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.4.0.tgz",
-            "integrity": "sha1-nHSuKvCzUPpmr6PBVBqdtYi5a9s=",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.4.1.tgz",
+            "integrity": "sha1-XlX0ibLV8CyQjCswm/CBTxXHV74=",
             "dev": true,
             "requires": {
-                "babel-helper-flip-expressions": "0.4.0",
+                "babel-helper-flip-expressions": "0.4.1",
                 "babel-helper-is-nodes-equiv": "0.0.1",
-                "babel-helper-to-multiple-sequence-expressions": "0.4.0"
+                "babel-helper-to-multiple-sequence-expressions": "0.4.1"
             }
         },
         "babel-plugin-minify-type-constructors": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.4.0.tgz",
-            "integrity": "sha1-NGfDyEfG1vLDuACUFLSshXqpuzY=",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.4.1.tgz",
+            "integrity": "sha1-eSJNE0bDPk+kQnVqI0JkkVjvlEg=",
             "dev": true,
             "requires": {
-                "babel-helper-is-void-0": "0.4.0"
+                "babel-helper-is-void-0": "0.4.1"
             }
         },
         "babel-plugin-syntax-class-properties": {
@@ -1504,30 +1468,9 @@
                     "integrity": "sha512-flMsJ9eSpShupt2Gwpka84DoMePvE4HlDObzdEc+1iNkacv3+NHlsJ7dMKmbnVA/AT22UhcGEBHwbJLoXWBO6Q==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.4.0",
+                        "chalk": "2.4.1",
                         "esutils": "2.0.2",
                         "js-tokens": "3.0.2"
-                    }
-                },
-                "babel-helper-function-name": {
-                    "version": "7.0.0-beta.3",
-                    "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-beta.3.tgz",
-                    "integrity": "sha512-iMWYqwDarQOVlEGcK1MfbtK9vrFGs5Z4UQsdASJUHdhBp918EM5kndwriiIbhUX8gr2B/CEV/udJkFTrHsjdMQ==",
-                    "dev": true,
-                    "requires": {
-                        "babel-helper-get-function-arity": "7.0.0-beta.3",
-                        "babel-template": "7.0.0-beta.3",
-                        "babel-traverse": "7.0.0-beta.3",
-                        "babel-types": "7.0.0-beta.3"
-                    }
-                },
-                "babel-helper-get-function-arity": {
-                    "version": "7.0.0-beta.3",
-                    "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-beta.3.tgz",
-                    "integrity": "sha512-ZkYFRMWKx1c9fUW72YNM3eieBG701CMbLjmLLWmJTTPc0F0kddS9Fwok26EAmndUAgD6kFdh7ms3PH94MdGuGQ==",
-                    "dev": true,
-                    "requires": {
-                        "babel-types": "7.0.0-beta.3"
                     }
                 },
                 "babel-template": {
@@ -1601,6 +1544,12 @@
                 "babel-template": "6.26.0"
             }
         },
+        "babel-plugin-transform-es2015-destructuring": {
+            "version": "7.0.0-beta.3",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-7.0.0-beta.3.tgz",
+            "integrity": "sha512-BDjEuIS7SCI7mGEO8lfvo4f3UAVLwZYjHwt1WqRNklc1Y0mcY0/UZzM3NHoa+eBxkNPl5XApwyha/rxW3XyLUQ==",
+            "dev": true
+        },
         "babel-plugin-transform-es2015-modules-commonjs": {
             "version": "6.26.2",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
@@ -1613,28 +1562,112 @@
                 "babel-types": "6.26.0"
             }
         },
+        "babel-plugin-transform-es2015-parameters": {
+            "version": "7.0.0-beta.3",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-7.0.0-beta.3.tgz",
+            "integrity": "sha512-0LdLhxyhIZz5y+1jfRSM7uBen5dCIft3KWwLbr/Wy3Amz9V4Mnfn1mr25BIBDL/RTNYpZGrJ2DWan7KD7DoHEA==",
+            "dev": true,
+            "requires": {
+                "babel-helper-call-delegate": "7.0.0-beta.3",
+                "babel-helper-get-function-arity": "7.0.0-beta.3",
+                "babel-template": "7.0.0-beta.3",
+                "babel-traverse": "7.0.0-beta.3",
+                "babel-types": "7.0.0-beta.3"
+            },
+            "dependencies": {
+                "babel-code-frame": {
+                    "version": "7.0.0-beta.3",
+                    "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-beta.3.tgz",
+                    "integrity": "sha512-flMsJ9eSpShupt2Gwpka84DoMePvE4HlDObzdEc+1iNkacv3+NHlsJ7dMKmbnVA/AT22UhcGEBHwbJLoXWBO6Q==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "2.4.1",
+                        "esutils": "2.0.2",
+                        "js-tokens": "3.0.2"
+                    }
+                },
+                "babel-template": {
+                    "version": "7.0.0-beta.3",
+                    "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-7.0.0-beta.3.tgz",
+                    "integrity": "sha512-urJduLja89kSDGqY8ryw8iIwQnMl30IvhMtMNmDD7vBX0l0oylaLgK+7df/9ODX9vR/PhXuif6HYl5HlzAKXMg==",
+                    "dev": true,
+                    "requires": {
+                        "babel-code-frame": "7.0.0-beta.3",
+                        "babel-traverse": "7.0.0-beta.3",
+                        "babel-types": "7.0.0-beta.3",
+                        "babylon": "7.0.0-beta.27",
+                        "lodash": "4.17.5"
+                    }
+                },
+                "babel-traverse": {
+                    "version": "7.0.0-beta.3",
+                    "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-beta.3.tgz",
+                    "integrity": "sha512-xyh/aPYuedMAfQlSj2kjHjsEmY5/Dpxs576L05DySAVMrV+ADX6l4mTOLysAEGwJfkePJlDLhFuS6SKaxv1V7w==",
+                    "dev": true,
+                    "requires": {
+                        "babel-code-frame": "7.0.0-beta.3",
+                        "babel-helper-function-name": "7.0.0-beta.3",
+                        "babel-types": "7.0.0-beta.3",
+                        "babylon": "7.0.0-beta.27",
+                        "debug": "3.1.0",
+                        "globals": "10.4.0",
+                        "invariant": "2.2.4",
+                        "lodash": "4.17.5"
+                    }
+                },
+                "babel-types": {
+                    "version": "7.0.0-beta.3",
+                    "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-beta.3.tgz",
+                    "integrity": "sha512-36k8J+byAe181OmCMawGhw+DtKO7AwexPVtsPXoMfAkjtZgoCX3bEuHWfdE5sYxRM8dojvtG/+O08M0Z/YDC6w==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "2.0.2",
+                        "lodash": "4.17.5",
+                        "to-fast-properties": "2.0.0"
+                    }
+                },
+                "babylon": {
+                    "version": "7.0.0-beta.27",
+                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.27.tgz",
+                    "integrity": "sha512-ksRx+r8eFIfdt63MCgLc9VxGL7W3jcyveQvMpNMVHgW+eb9mq3Xbm45FLCNkw8h92RvoNp4uuiwzcCEwxjDBZg==",
+                    "dev": true
+                },
+                "globals": {
+                    "version": "10.4.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-10.4.0.tgz",
+                    "integrity": "sha512-uNUtxIZpGyuaq+5BqGGQHsL4wUlJAXRqOm6g3Y48/CWNGTLONgBibI0lh6lGxjR2HljFYUfszb+mk4WkgMntsA==",
+                    "dev": true
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
+        },
         "babel-plugin-transform-inline-consecutive-adds": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.4.0.tgz",
-            "integrity": "sha1-GqB1oSxrWhOMspQkfuEXKpieFOA=",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.4.1.tgz",
+            "integrity": "sha1-F13t/odsL/enjHUe1NncBZfRFx0=",
             "dev": true
         },
         "babel-plugin-transform-member-expression-literals": {
-            "version": "6.9.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.9.1.tgz",
-            "integrity": "sha1-lr4umWjn9UlzM64DKE7NU0BAVIk=",
+            "version": "6.9.2",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.9.2.tgz",
+            "integrity": "sha1-Hzl6uWGlw6QB8qdHrwbnIASvy3Y=",
             "dev": true
         },
         "babel-plugin-transform-merge-sibling-variables": {
-            "version": "6.9.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.9.1.tgz",
-            "integrity": "sha1-kHHkQ7IUWM5rCo04QbpaF09dwoI=",
+            "version": "6.9.2",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.9.2.tgz",
+            "integrity": "sha1-mUqQBKecefDJHEluii28fptz97Q=",
             "dev": true
         },
         "babel-plugin-transform-minify-booleans": {
-            "version": "6.9.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.1.tgz",
-            "integrity": "sha1-UsunnAD6UJc3BkBV76siFm4UDE0=",
+            "version": "6.9.2",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.2.tgz",
+            "integrity": "sha1-z5lb4GegMDy1JlSfA9zZaCQZQw0=",
             "dev": true
         },
         "babel-plugin-transform-object-rest-spread": {
@@ -1655,45 +1688,45 @@
             }
         },
         "babel-plugin-transform-property-literals": {
-            "version": "6.9.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.9.1.tgz",
-            "integrity": "sha1-aXD5Oxd5OrzenPJdLozRPgCI5ck=",
+            "version": "6.9.2",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.9.2.tgz",
+            "integrity": "sha1-pY0Jls8q2vIk986EitHN5M2M8nU=",
             "dev": true,
             "requires": {
                 "esutils": "2.0.2"
             }
         },
         "babel-plugin-transform-regexp-constructors": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.4.0.tgz",
-            "integrity": "sha1-dWu0XAOBPcNpWQntAni0IZ9uxsw=",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.4.1.tgz",
+            "integrity": "sha1-T/fx2g4MMZENDhRhq+0MZ5yzHu4=",
             "dev": true
         },
         "babel-plugin-transform-remove-console": {
-            "version": "6.9.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.1.tgz",
-            "integrity": "sha1-QP6V2YyuWBHYoOGImBLXixKFllE=",
+            "version": "6.9.2",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.2.tgz",
+            "integrity": "sha1-6KDCfVbJUDyhbihPa2Tb1LldIek=",
             "dev": true
         },
         "babel-plugin-transform-remove-debugger": {
-            "version": "6.9.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.9.1.tgz",
-            "integrity": "sha1-dlUtLp1sQ9nGdrv8CPPCoswUvhQ=",
+            "version": "6.9.2",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.9.2.tgz",
+            "integrity": "sha1-U2yHvbYgDRRgyZbdldF5zzjCTuE=",
             "dev": true
         },
         "babel-plugin-transform-remove-undefined": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.4.0.tgz",
-            "integrity": "sha1-+ipRMK6HTJlDKpvESiT7YZvA8sc=",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.4.1.tgz",
+            "integrity": "sha1-Y2x/KM66/Fpm+jT5TGCAR+r3508=",
             "dev": true,
             "requires": {
-                "babel-helper-evaluate-path": "0.4.0"
+                "babel-helper-evaluate-path": "0.4.1"
             }
         },
         "babel-plugin-transform-simplify-comparison-operators": {
-            "version": "6.9.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.1.tgz",
-            "integrity": "sha1-Ww0GmAoXp4D1MYsnTAC+L7HHxP4=",
+            "version": "6.9.2",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.2.tgz",
+            "integrity": "sha1-DA6a+nMpJPA6qYL9Y8ktBAi9VlY=",
             "dev": true
         },
         "babel-plugin-transform-strict-mode": {
@@ -1707,39 +1740,39 @@
             }
         },
         "babel-plugin-transform-undefined-to-void": {
-            "version": "6.9.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.1.tgz",
-            "integrity": "sha1-19+cHdDsEuD/6JXtFEX2Hxv14iE=",
+            "version": "6.9.2",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.2.tgz",
+            "integrity": "sha1-Fl/eczkydr6gKnOWWIeNzO0Lnrs=",
             "dev": true
         },
         "babel-preset-minify": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.4.0.tgz",
-            "integrity": "sha1-NOYHdoM2LN2nYR1SLgZOAsFBN/s=",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.4.1.tgz",
+            "integrity": "sha1-QOPtrXQ7sQfdY8fPshxgTczYNnQ=",
             "dev": true,
             "requires": {
-                "babel-plugin-minify-builtins": "0.4.0",
-                "babel-plugin-minify-constant-folding": "0.4.0",
-                "babel-plugin-minify-dead-code-elimination": "0.4.0",
-                "babel-plugin-minify-flip-comparisons": "0.4.0",
-                "babel-plugin-minify-guarded-expressions": "0.4.0",
-                "babel-plugin-minify-infinity": "0.4.0",
-                "babel-plugin-minify-mangle-names": "0.4.0",
-                "babel-plugin-minify-numeric-literals": "0.4.0",
-                "babel-plugin-minify-replace": "0.4.0",
-                "babel-plugin-minify-simplify": "0.4.0",
-                "babel-plugin-minify-type-constructors": "0.4.0",
-                "babel-plugin-transform-inline-consecutive-adds": "0.4.0",
-                "babel-plugin-transform-member-expression-literals": "6.9.1",
-                "babel-plugin-transform-merge-sibling-variables": "6.9.1",
-                "babel-plugin-transform-minify-booleans": "6.9.1",
-                "babel-plugin-transform-property-literals": "6.9.1",
-                "babel-plugin-transform-regexp-constructors": "0.4.0",
-                "babel-plugin-transform-remove-console": "6.9.1",
-                "babel-plugin-transform-remove-debugger": "6.9.1",
-                "babel-plugin-transform-remove-undefined": "0.4.0",
-                "babel-plugin-transform-simplify-comparison-operators": "6.9.1",
-                "babel-plugin-transform-undefined-to-void": "6.9.1",
+                "babel-plugin-minify-builtins": "0.4.1",
+                "babel-plugin-minify-constant-folding": "0.4.1",
+                "babel-plugin-minify-dead-code-elimination": "0.4.1",
+                "babel-plugin-minify-flip-comparisons": "0.4.1",
+                "babel-plugin-minify-guarded-expressions": "0.4.1",
+                "babel-plugin-minify-infinity": "0.4.1",
+                "babel-plugin-minify-mangle-names": "0.4.1",
+                "babel-plugin-minify-numeric-literals": "0.4.1",
+                "babel-plugin-minify-replace": "0.4.1",
+                "babel-plugin-minify-simplify": "0.4.1",
+                "babel-plugin-minify-type-constructors": "0.4.1",
+                "babel-plugin-transform-inline-consecutive-adds": "0.4.1",
+                "babel-plugin-transform-member-expression-literals": "6.9.2",
+                "babel-plugin-transform-merge-sibling-variables": "6.9.2",
+                "babel-plugin-transform-minify-booleans": "6.9.2",
+                "babel-plugin-transform-property-literals": "6.9.2",
+                "babel-plugin-transform-regexp-constructors": "0.4.1",
+                "babel-plugin-transform-remove-console": "6.9.2",
+                "babel-plugin-transform-remove-debugger": "6.9.2",
+                "babel-plugin-transform-remove-undefined": "0.4.1",
+                "babel-plugin-transform-simplify-comparison-operators": "6.9.2",
+                "babel-plugin-transform-undefined-to-void": "6.9.2",
                 "lodash.isplainobject": "4.0.6"
             }
         },
@@ -2036,9 +2069,9 @@
             }
         },
         "chalk": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-            "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+            "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
             "dev": true,
             "requires": {
                 "ansi-styles": "3.2.1",
@@ -2196,6 +2229,15 @@
             "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
             "requires": {
                 "delayed-stream": "1.0.0"
+            }
+        },
+        "commander": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+            "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+            "dev": true,
+            "requires": {
+                "graceful-readlink": "1.0.1"
             }
         },
         "commondir": {
@@ -2419,17 +2461,16 @@
             }
         },
         "del": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-            "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+            "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
             "dev": true,
             "requires": {
-                "globby": "5.0.0",
+                "globby": "6.1.0",
                 "is-path-cwd": "1.0.0",
                 "is-path-in-cwd": "1.0.1",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
+                "p-map": "1.2.0",
+                "pify": "3.0.0",
                 "rimraf": "2.6.2"
             }
         },
@@ -2611,13 +2652,6 @@
                 "source-map": "0.6.1"
             },
             "dependencies": {
-                "esprima": {
-                    "version": "3.1.3",
-                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-                    "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-                    "dev": true,
-                    "optional": true
-                },
                 "source-map": {
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -2644,19 +2678,6 @@
                 "marked": "0.3.19",
                 "minimist": "1.2.0",
                 "taffydb": "2.7.3"
-            },
-            "dependencies": {
-                "fs-extra": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-                    "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "4.1.11",
-                        "jsonfile": "4.0.0",
-                        "universalify": "0.1.1"
-                    }
-                }
             }
         },
         "esdoc-accessor-plugin": {
@@ -2907,7 +2928,7 @@
             "requires": {
                 "ajv": "5.5.2",
                 "babel-code-frame": "6.26.0",
-                "chalk": "2.4.0",
+                "chalk": "2.4.1",
                 "concat-stream": "1.6.2",
                 "cross-spawn": "5.1.0",
                 "debug": "3.1.0",
@@ -2920,8 +2941,8 @@
                 "file-entry-cache": "2.0.0",
                 "functional-red-black-tree": "1.0.1",
                 "glob": "7.1.2",
-                "globals": "11.4.0",
-                "ignore": "3.3.7",
+                "globals": "11.5.0",
+                "ignore": "3.3.8",
                 "imurmurhash": "0.1.4",
                 "inquirer": "3.3.0",
                 "is-resolvable": "1.1.0",
@@ -3102,6 +3123,12 @@
                         "pify": "2.3.0"
                     }
                 },
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
+                },
                 "read-pkg": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -3173,13 +3200,22 @@
             "requires": {
                 "acorn": "5.5.3",
                 "acorn-jsx": "3.0.1"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "5.5.3",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+                    "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+                    "dev": true
+                }
             }
         },
         "esprima": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-            "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-            "dev": true
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+            "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+            "dev": true,
+            "optional": true
         },
         "esquery": {
             "version": "1.0.1",
@@ -3576,6 +3612,43 @@
                 "del": "2.2.2",
                 "graceful-fs": "4.1.11",
                 "write": "0.2.1"
+            },
+            "dependencies": {
+                "del": {
+                    "version": "2.2.2",
+                    "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+                    "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+                    "dev": true,
+                    "requires": {
+                        "globby": "5.0.0",
+                        "is-path-cwd": "1.0.0",
+                        "is-path-in-cwd": "1.0.1",
+                        "object-assign": "4.1.1",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1",
+                        "rimraf": "2.6.2"
+                    }
+                },
+                "globby": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+                    "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+                    "dev": true,
+                    "requires": {
+                        "array-union": "1.0.2",
+                        "arrify": "1.0.1",
+                        "glob": "7.1.2",
+                        "object-assign": "4.1.1",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
+                    }
+                },
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
+                }
             }
         },
         "for-in": {
@@ -3622,6 +3695,17 @@
             "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
             "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
             "dev": true
+        },
+        "fs-extra": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+            "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "jsonfile": "4.0.0",
+                "universalify": "0.1.1"
+            }
         },
         "fs.realpath": {
             "version": "1.0.0",
@@ -3863,23 +3947,30 @@
             }
         },
         "globals": {
-            "version": "11.4.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
-            "integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA==",
+            "version": "11.5.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.5.0.tgz",
+            "integrity": "sha512-hYyf+kI8dm3nORsiiXUQigOU62hDLfJ9G01uyGMxhc6BKsircrUhC4uJPQPUSuq2GrTmiiEt7ewxlMdBewfmKQ==",
             "dev": true
         },
         "globby": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-            "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+            "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
             "dev": true,
             "requires": {
                 "array-union": "1.0.2",
-                "arrify": "1.0.1",
                 "glob": "7.1.2",
                 "object-assign": "4.1.1",
                 "pify": "2.3.0",
                 "pinkie-promise": "2.0.1"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
+                }
             }
         },
         "globule": {
@@ -4009,6 +4100,26 @@
                 }
             }
         },
+        "gulp-babel": {
+            "version": "8.0.0-beta.2",
+            "resolved": "https://registry.npmjs.org/gulp-babel/-/gulp-babel-8.0.0-beta.2.tgz",
+            "integrity": "sha512-GTC2PxAXWkp6u1fP+C5+kn5biQ0dKGhkOSSXvKAf3ykF0+R3tevmLm/zSIkc1+S7U1JwH3XTvuMwRL6LD+sEiw==",
+            "dev": true,
+            "requires": {
+                "plugin-error": "1.0.1",
+                "replace-ext": "1.0.0",
+                "through2": "2.0.3",
+                "vinyl-sourcemaps-apply": "0.2.1"
+            },
+            "dependencies": {
+                "replace-ext": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+                    "dev": true
+                }
+            }
+        },
         "gulp-chug": {
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/gulp-chug/-/gulp-chug-0.5.1.tgz",
@@ -4027,7 +4138,7 @@
             "integrity": "sha512-2LZzP+ydczqz1rhqq/NYxvVvYTmOa0IgBl2B1sQTdkQgku9ayOUM/KHuGPjF4QA5aO1VcG+Sskw7iCcRUqHKkA==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.0",
+                "chalk": "2.4.1",
                 "fancy-log": "1.3.2",
                 "plur": "2.1.2",
                 "stringify-object": "3.2.2",
@@ -4454,6 +4565,12 @@
             "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
             "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
         },
+        "home-or-tmp": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-3.0.0.tgz",
+            "integrity": "sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs=",
+            "dev": true
+        },
         "homedir-polyfill": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
@@ -4589,9 +4706,9 @@
             }
         },
         "ignore": {
-            "version": "3.3.7",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-            "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+            "version": "3.3.8",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
+            "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg==",
             "dev": true
         },
         "imurmurhash": {
@@ -4629,7 +4746,7 @@
             "dev": true,
             "requires": {
                 "ansi-escapes": "3.1.0",
-                "chalk": "2.4.0",
+                "chalk": "2.4.1",
                 "cli-cursor": "2.1.0",
                 "cli-width": "2.2.0",
                 "external-editor": "2.2.0",
@@ -4649,22 +4766,6 @@
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
                     "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
                     "dev": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                    "dev": true
-                },
-                "string-width": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-                    "dev": true,
-                    "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
-                    }
                 },
                 "strip-ansi": {
                     "version": "4.0.0",
@@ -4823,6 +4924,12 @@
             "requires": {
                 "number-is-nan": "1.0.1"
             }
+        },
+        "is-fullwidth-code-point": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+            "dev": true
         },
         "is-glob": {
             "version": "3.1.0",
@@ -5037,6 +5144,14 @@
             "requires": {
                 "argparse": "1.0.10",
                 "esprima": "4.0.0"
+            },
+            "dependencies": {
+                "esprima": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+                    "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+                    "dev": true
+                }
             }
         },
         "jsbn": {
@@ -5069,13 +5184,6 @@
                 "xml-name-validator": "2.0.1"
             },
             "dependencies": {
-                "acorn": {
-                    "version": "2.7.0",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
-                    "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
-                    "dev": true,
-                    "optional": true
-                },
                 "parse5": {
                     "version": "1.5.1",
                     "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
@@ -5084,6 +5192,12 @@
                     "optional": true
                 }
             }
+        },
+        "jsesc": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+            "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+            "dev": true
         },
         "json-schema": {
             "version": "0.2.3",
@@ -5219,6 +5333,12 @@
                 "strip-bom": "2.0.0"
             },
             "dependencies": {
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
+                },
                 "strip-bom": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
@@ -5507,14 +5627,6 @@
             "dev": true,
             "requires": {
                 "pify": "3.0.0"
-            },
-            "dependencies": {
-                "pify": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-                    "dev": true
-                }
             }
         },
         "make-iterator": {
@@ -5699,15 +5811,6 @@
                     "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
                     "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
                     "dev": true
-                },
-                "commander": {
-                    "version": "2.9.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                    "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-readlink": "1.0.1"
-                    }
                 },
                 "debug": {
                     "version": "2.6.8",
@@ -8883,7 +8986,7 @@
             "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
             "dev": true,
             "requires": {
-                "@types/node": "10.0.2"
+                "@types/node": "10.0.3"
             }
         },
         "pascalcase": {
@@ -8957,6 +9060,14 @@
                 "graceful-fs": "4.1.11",
                 "pify": "2.3.0",
                 "pinkie-promise": "2.0.1"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
+                }
             }
         },
         "pathval": {
@@ -8971,9 +9082,9 @@
             "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
         },
         "pify": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
             "dev": true
         },
         "pinkie": {
@@ -9537,14 +9648,6 @@
             "dev": true,
             "requires": {
                 "is-fullwidth-code-point": "2.0.0"
-            },
-            "dependencies": {
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                    "dev": true
-                }
             }
         },
         "snapdragon": {
@@ -9810,6 +9913,33 @@
             "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
             "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
         },
+        "string-width": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+            "dev": true,
+            "requires": {
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "3.0.0"
+                    }
+                }
+            }
+        },
         "string_decoder": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -9881,43 +10011,10 @@
             "requires": {
                 "ajv": "5.5.2",
                 "ajv-keywords": "2.1.1",
-                "chalk": "2.4.0",
+                "chalk": "2.4.1",
                 "lodash": "4.17.5",
                 "slice-ansi": "1.0.0",
                 "string-width": "2.1.1"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                    "dev": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                    "dev": true
-                },
-                "string-width": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-                    "dev": true,
-                    "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "3.0.0"
-                    }
-                }
             }
         },
         "taffydb": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"request-promise-native": "^1.0.5"
 	},
 	"devDependencies": {
-		"appcd-gulp": "^1.1.1",
+		"appcd-gulp": "^1.1.3",
 		"babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
 		"gulp": "^3.9.1",
 		"mocha": "^5.1.1",


### PR DESCRIPTION
- Update the `appcd-gulp` version to fix some bugs
- Add a simple Jenkinsfile that installs stuff then runs `gulp coverage`

I've left the "babel-plugin-transform-es2015-modules-commonjs", nyc, and mocha deps to avoid any merge conflicts incase you had them removed locally, if you want me to nuke them I can do